### PR TITLE
09272025 - Update PO Receiving only create cache payable for freight …

### DIFF
--- a/src/main/java/org/guanzon/cas/purchasing/controller/PurchaseOrderReceiving.java
+++ b/src/main/java/org/guanzon/cas/purchasing/controller/PurchaseOrderReceiving.java
@@ -3491,7 +3491,7 @@ public class PurchaseOrderReceiving extends Transaction {
         poCachePayableTrucking.Master().setSourceNo(Master().getTransactionNo());
         poCachePayableTrucking.Master().setReferNo(Master().getReferenceNo()); 
         poCachePayableTrucking.Master().setGrossAmount(Master().getFreight().doubleValue()); 
-        poCachePayableTrucking.Master().setFreight(Master().getFreight().doubleValue());
+//        poCachePayableTrucking.Master().setFreight(Master().getFreight().doubleValue()); //Do not set the freight since detail has already a freight
         poCachePayableTrucking.Master().setNetTotal(Master().getFreight().doubleValue()); 
         poCachePayableTrucking.Master().setPayables(Master().getFreight().doubleValue()); 
 //        poCachePayableTrucking.Master().setDiscountAmount(ldblTotalDiscAmt); 


### PR DESCRIPTION
…when trucking is not empty and not equal to the supplier

- Update PO Receiving only create cache payable for freight when trucking is not empty and not equal to the supplier